### PR TITLE
std: update Rust toolchain to nightly-2026-08-05

### DIFF
--- a/aarch64-unknown-optee.json
+++ b/aarch64-unknown-optee.json
@@ -16,6 +16,6 @@
     "target-endian": "little",
     "target-pointer-width": 64,
     "vendor": "unknown",
-    "panic-strategy": "abort"
+    "panic-strategy": "abort",
+    "singlethread": true
   }
-  

--- a/crates/optee-utee-sys/src/tee_api.rs
+++ b/crates/optee-utee-sys/src/tee_api.rs
@@ -150,8 +150,8 @@ pub mod api {
             maxObjectSize: u32,
             object: *mut TEE_ObjectHandle,
         ) -> TEE_Result;
-        pub fn TEE_FreeTransientObject(object: TEE_ObjectHandle) -> c_void;
-        pub fn TEE_ResetTransientObject(object: TEE_ObjectHandle) -> c_void;
+        pub fn TEE_FreeTransientObject(object: TEE_ObjectHandle);
+        pub fn TEE_ResetTransientObject(object: TEE_ObjectHandle);
         pub fn TEE_PopulateTransientObject(
             object: TEE_ObjectHandle,
             attrs: *const TEE_Attribute,
@@ -162,17 +162,9 @@ pub mod api {
             attributeID: u32,
             buffer: *const c_void,
             length: usize,
-        ) -> c_void;
-        pub fn TEE_InitValueAttribute(
-            attr: *mut TEE_Attribute,
-            attributeID: u32,
-            a: u32,
-            b: u32,
-        ) -> c_void;
-        pub fn TEE_CopyObjectAttributes(
-            destObject: TEE_ObjectHandle,
-            srcObject: TEE_ObjectHandle,
-        ) -> c_void;
+        );
+        pub fn TEE_InitValueAttribute(attr: *mut TEE_Attribute, attributeID: u32, a: u32, b: u32);
+        pub fn TEE_CopyObjectAttributes(destObject: TEE_ObjectHandle, srcObject: TEE_ObjectHandle);
         pub fn TEE_CopyObjectAttributes1(
             destObject: TEE_ObjectHandle,
             srcObject: TEE_ObjectHandle,
@@ -254,17 +246,17 @@ pub mod api {
             mode: u32,
             maxKeySize: u32,
         ) -> TEE_Result;
-        pub fn TEE_FreeOperation(operation: TEE_OperationHandle) -> c_void;
+        pub fn TEE_FreeOperation(operation: TEE_OperationHandle);
         pub fn TEE_GetOperationInfo(
             operation: TEE_OperationHandle,
             operationInfo: *mut TEE_OperationInfo,
-        ) -> c_void;
+        );
         pub fn TEE_GetOperationInfoMultiple(
             operation: TEE_OperationHandle,
             operationInfoMultiple: *mut TEE_OperationInfoMultiple,
             operationSize: *mut usize,
         ) -> TEE_Result;
-        pub fn TEE_ResetOperation(operation: TEE_OperationHandle) -> c_void;
+        pub fn TEE_ResetOperation(operation: TEE_OperationHandle);
         pub fn TEE_SetOperationKey(
             operation: TEE_OperationHandle,
             key: TEE_ObjectHandle,
@@ -277,7 +269,7 @@ pub mod api {
         pub fn TEE_CopyOperation(
             dstOperation: TEE_OperationHandle,
             srcOperation: TEE_OperationHandle,
-        ) -> c_void;
+        );
         pub fn TEE_IsAlgorithmSupported(algId: u32, element: u32) -> TEE_Result;
 
         // Cryptographic Operations API - Message Digest Functions
@@ -286,7 +278,7 @@ pub mod api {
             operation: TEE_OperationHandle,
             chunk: *const c_void,
             chunkSize: usize,
-        ) -> c_void;
+        );
         pub fn TEE_DigestDoFinal(
             operation: TEE_OperationHandle,
             chunk: *const c_void,
@@ -297,11 +289,7 @@ pub mod api {
 
         // Cryptographic Operations API - Symmetric Cipher Functions
 
-        pub fn TEE_CipherInit(
-            operation: TEE_OperationHandle,
-            IV: *const c_void,
-            IVLen: usize,
-        ) -> c_void;
+        pub fn TEE_CipherInit(operation: TEE_OperationHandle, IV: *const c_void, IVLen: usize);
         pub fn TEE_CipherUpdate(
             operation: TEE_OperationHandle,
             srcData: *const c_void,
@@ -319,16 +307,12 @@ pub mod api {
 
         // Cryptographic Operations API - MAC Functions
 
-        pub fn TEE_MACInit(
-            operation: TEE_OperationHandle,
-            IV: *const c_void,
-            IVLen: usize,
-        ) -> c_void;
+        pub fn TEE_MACInit(operation: TEE_OperationHandle, IV: *const c_void, IVLen: usize);
         pub fn TEE_MACUpdate(
             operation: TEE_OperationHandle,
             chunk: *const c_void,
             chunkSize: usize,
-        ) -> c_void;
+        );
         pub fn TEE_MACComputeFinal(
             operation: TEE_OperationHandle,
             message: *const c_void,
@@ -358,7 +342,7 @@ pub mod api {
             operation: TEE_OperationHandle,
             AADdata: *const c_void,
             AADdataLen: usize,
-        ) -> c_void;
+        );
         pub fn TEE_AEUpdate(
             operation: TEE_OperationHandle,
             srcData: *const c_void,
@@ -431,19 +415,19 @@ pub mod api {
             params: *const TEE_Attribute,
             paramCount: u32,
             derivedKey: TEE_ObjectHandle,
-        ) -> c_void;
+        );
 
         // Cryptographic Operations API - Random Number Generation Functions
 
-        pub fn TEE_GenerateRandom(randomBuffer: *mut c_void, randomBufferLen: usize) -> c_void;
+        pub fn TEE_GenerateRandom(randomBuffer: *mut c_void, randomBufferLen: usize);
 
         // Date & Time API
 
-        pub fn TEE_GetSystemTime(time: *mut TEE_Time) -> c_void;
+        pub fn TEE_GetSystemTime(time: *mut TEE_Time);
         pub fn TEE_Wait(timeout: u32) -> TEE_Result;
         pub fn TEE_GetTAPersistentTime(time: *mut TEE_Time) -> TEE_Result;
         pub fn TEE_SetTAPersistentTime(time: *const TEE_Time) -> TEE_Result;
-        pub fn TEE_GetREETime(time: *mut TEE_Time) -> c_void;
+        pub fn TEE_GetREETime(time: *mut TEE_Time);
 
         // TEE Arithmetical API - Memory allocation and size of objects
 
@@ -452,13 +436,13 @@ pub mod api {
 
         // TEE Arithmetical API - Initialization functions
 
-        pub fn TEE_BigIntInit(bigInt: *mut TEE_BigInt, len: usize) -> c_void;
+        pub fn TEE_BigIntInit(bigInt: *mut TEE_BigInt, len: usize);
         pub fn TEE_BigIntInitFMMContext(
             context: *mut TEE_BigIntFMMContext,
             len: usize,
             modulus: *const TEE_BigInt,
-        ) -> c_void;
-        pub fn TEE_BigIntInitFMM(bigIntFMM: *mut TEE_BigIntFMM, len: usize) -> c_void;
+        );
+        pub fn TEE_BigIntInitFMM(bigIntFMM: *mut TEE_BigIntFMM, len: usize);
 
         // TEE Arithmetical API - Converter functions
 
@@ -473,82 +457,58 @@ pub mod api {
             bufferLen: *mut usize,
             bigInt: *const TEE_BigInt,
         ) -> TEE_Result;
-        pub fn TEE_BigIntConvertFromS32(dest: *mut TEE_BigInt, shortVal: i32) -> c_void;
+        pub fn TEE_BigIntConvertFromS32(dest: *mut TEE_BigInt, shortVal: i32);
         pub fn TEE_BigIntConvertToS32(dest: *mut i32, src: *const TEE_BigInt) -> TEE_Result;
 
         // TEE Arithmetical API - Logical operations
 
         pub fn TEE_BigIntCmp(op1: *const TEE_BigInt, op2: *const TEE_BigInt) -> i32;
         pub fn TEE_BigIntCmpS32(op: *const TEE_BigInt, shortVal: i32) -> i32;
-        pub fn TEE_BigIntShiftRight(
-            dest: *mut TEE_BigInt,
-            op: *const TEE_BigInt,
-            bits: size_t,
-        ) -> c_void;
+        pub fn TEE_BigIntShiftRight(dest: *mut TEE_BigInt, op: *const TEE_BigInt, bits: size_t);
         pub fn TEE_BigIntGetBit(src: *const TEE_BigInt, bitIndex: u32) -> bool;
         pub fn TEE_BigIntGetBitCount(src: *const TEE_BigInt) -> u32;
         pub fn TEE_BigIntSetBit(src: *mut TEE_BigInt, bitIndex: u32, value: bool) -> TEE_Result;
         pub fn TEE_BigIntAssign(dest: *mut TEE_BigInt, src: *const TEE_BigInt) -> TEE_Result;
         pub fn TEE_BigIntAbs(dest: *mut TEE_BigInt, src: *const TEE_BigInt) -> TEE_Result;
-        pub fn TEE_BigIntAdd(
-            dest: *mut TEE_BigInt,
-            op1: *const TEE_BigInt,
-            op2: *const TEE_BigInt,
-        ) -> c_void;
-        pub fn TEE_BigIntSub(
-            dest: *mut TEE_BigInt,
-            op1: *const TEE_BigInt,
-            op2: *const TEE_BigInt,
-        ) -> c_void;
-        pub fn TEE_BigIntNeg(dest: *mut TEE_BigInt, op: *const TEE_BigInt) -> c_void;
-        pub fn TEE_BigIntMul(
-            dest: *mut TEE_BigInt,
-            op1: *const TEE_BigInt,
-            op2: *const TEE_BigInt,
-        ) -> c_void;
-        pub fn TEE_BigIntSquare(dest: *mut TEE_BigInt, op: *const TEE_BigInt) -> c_void;
+        pub fn TEE_BigIntAdd(dest: *mut TEE_BigInt, op1: *const TEE_BigInt, op2: *const TEE_BigInt);
+        pub fn TEE_BigIntSub(dest: *mut TEE_BigInt, op1: *const TEE_BigInt, op2: *const TEE_BigInt);
+        pub fn TEE_BigIntNeg(dest: *mut TEE_BigInt, op: *const TEE_BigInt);
+        pub fn TEE_BigIntMul(dest: *mut TEE_BigInt, op1: *const TEE_BigInt, op2: *const TEE_BigInt);
+        pub fn TEE_BigIntSquare(dest: *mut TEE_BigInt, op: *const TEE_BigInt);
         pub fn TEE_BigIntDiv(
             dest_q: *mut TEE_BigInt,
             dest_r: *mut TEE_BigInt,
             op1: *const TEE_BigInt,
             op2: *const TEE_BigInt,
-        ) -> c_void;
+        );
 
         // TEE Arithmetical API - Modular arithmetic operations
 
-        pub fn TEE_BigIntMod(
-            dest: *mut TEE_BigInt,
-            op: *const TEE_BigInt,
-            n: *const TEE_BigInt,
-        ) -> c_void;
+        pub fn TEE_BigIntMod(dest: *mut TEE_BigInt, op: *const TEE_BigInt, n: *const TEE_BigInt);
         pub fn TEE_BigIntAddMod(
             dest: *mut TEE_BigInt,
             op1: *const TEE_BigInt,
             op2: *const TEE_BigInt,
             n: *const TEE_BigInt,
-        ) -> c_void;
+        );
         pub fn TEE_BigIntSubMod(
             dest: *mut TEE_BigInt,
             op1: *const TEE_BigInt,
             op2: *const TEE_BigInt,
             n: *const TEE_BigInt,
-        ) -> c_void;
+        );
         pub fn TEE_BigIntMulMod(
             dest: *mut TEE_BigInt,
             op1: *const TEE_BigInt,
             op2: *const TEE_BigInt,
             n: *const TEE_BigInt,
-        ) -> c_void;
+        );
         pub fn TEE_BigIntSquareMod(
             dest: *mut TEE_BigInt,
             op: *const TEE_BigInt,
             n: *const TEE_BigInt,
-        ) -> c_void;
-        pub fn TEE_BigIntInvMod(
-            dest: *mut TEE_BigInt,
-            op: *const TEE_BigInt,
-            n: *const TEE_BigInt,
-        ) -> c_void;
+        );
+        pub fn TEE_BigIntInvMod(dest: *mut TEE_BigInt, op: *const TEE_BigInt, n: *const TEE_BigInt);
         pub fn TEE_BigIntExpMod(
             dest: *mut TEE_BigInt,
             op1: *const TEE_BigInt,
@@ -566,7 +526,7 @@ pub mod api {
             v: *mut TEE_BigInt,
             op1: *const TEE_BigInt,
             op2: *const TEE_BigInt,
-        ) -> c_void;
+        );
         pub fn TEE_BigIntIsProbablePrime(op: *const TEE_BigInt, confidenceLevel: u32) -> i32;
 
         // TEE Arithmetical API - Fast modular multiplication operations
@@ -576,19 +536,19 @@ pub mod api {
             src: *const TEE_BigInt,
             n: *const TEE_BigInt,
             context: *const TEE_BigIntFMMContext,
-        ) -> c_void;
+        );
         pub fn TEE_BigIntConvertFromFMM(
             dest: *mut TEE_BigInt,
             src: *const TEE_BigIntFMM,
             n: *const TEE_BigInt,
             context: *const TEE_BigIntFMMContext,
-        ) -> c_void;
+        );
         pub fn TEE_BigIntComputeFMM(
             dest: *mut TEE_BigIntFMM,
             op1: *const TEE_BigIntFMM,
             op2: *const TEE_BigIntFMM,
             n: *const TEE_BigInt,
             context: *const TEE_BigIntFMMContext,
-        ) -> c_void;
+        );
     }
 }

--- a/crates/optee-utee/src/macros.rs
+++ b/crates/optee-utee/src/macros.rs
@@ -36,7 +36,7 @@
 /// ```
 #[macro_export]
 macro_rules! trace_print {
-    ($($arg:tt)*) => ($crate::trace::Trace::_print(format_args!($($arg)*)));
+    ($($arg:tt)*) => {{ $crate::trace::Trace::_print(format_args!($($arg)*)) }};
 }
 
 /// Macro for printing to the trace output, with a newline.
@@ -53,12 +53,12 @@ macro_rules! trace_print {
 #[macro_export]
 macro_rules! trace_println {
     () => {
-        $crate::trace::Trace::_print(format_args!("\n"));
+        $crate::trace::Trace::_print(format_args!("\n"))
     };
     ($s:expr) => {
-        $crate::trace::Trace::_print(format_args!(concat!($s, "\n")));
+        $crate::trace::Trace::_print(format_args!(concat!($s, "\n")))
     };
     ($s:expr, $($tt:tt)*) => {
-        $crate::trace::Trace::_print(format_args!(concat!($s, "\n"), $($tt)*));
+        $crate::trace::Trace::_print(format_args!(concat!($s, "\n"), $($tt)*))
     };
 }

--- a/environment
+++ b/environment
@@ -45,7 +45,8 @@ then
     export TARGET_TA="arm-unknown-optee"
     echo "set TARGET_TA=$TARGET_TA (std)"
     export FEATURES="--features std"
-    export CARGO_FLAGS="-Z build-std=std,panic_abort"
+    export CARGO_FLAGS="-Z build-std=std,panic_abort -Z json-target-spec"
+    export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-Z unstable-options"
     export __CARGO_TESTS_ONLY_SRC_ROOT="$(pwd)/rust/rust/library"
   else
     export TARGET_TA="arm-unknown-linux-gnueabihf"
@@ -63,7 +64,8 @@ else
     export TARGET_TA="aarch64-unknown-optee"
     echo "set TARGET_TA=$TARGET_TA (std)"
     export FEATURES="--features std"
-    export CARGO_FLAGS="-Z build-std=std,panic_abort"
+    export CARGO_FLAGS="-Z build-std=std,panic_abort -Z json-target-spec"
+    export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-Z unstable-options"
     export __CARGO_TESTS_ONLY_SRC_ROOT="$(pwd)/rust/rust/library"
   else
     export TARGET_TA="aarch64-unknown-linux-gnu"

--- a/examples/ca/signature_verification-rs/src/main.rs
+++ b/examples/ca/signature_verification-rs/src/main.rs
@@ -61,13 +61,13 @@ fn main() -> optee_teec::Result<()> {
     let mut session = ctx.open_session(uuid)?;
 
     let message: &[u8] = b"hello,world";
-    println!("CA: message: {:?}", &message);
+    println!("CA: message: {:?}", message);
     let mut public_key = [0x00u8; PUBLIC_KEY_SIZE];
     let mut signature = [0x00u8; SIGNATURE_SIZE];
 
     sign(&mut session, message, &mut public_key, &mut signature)?;
-    println!("CA: public key: {:?}", &public_key);
-    println!("CA: signature: {:?}", &signature);
+    println!("CA: public key: {:?}", public_key);
+    println!("CA: signature: {:?}", signature);
 
     verify(&mut session, message, &public_key, &signature)?;
     println!("Success");

--- a/examples/ta/Makefile.include
+++ b/examples/ta/Makefile.include
@@ -38,7 +38,14 @@ clean:
 
 else
 
-RUSTFLAGS ?= -C panic=abort
+ifeq ($(findstring panic=abort,$(RUSTFLAGS)),)
+RUSTFLAGS += -C panic=abort
+endif
+ifneq ($(findstring json-target-spec,$(CARGO_FLAGS)),)
+ifeq ($(findstring unstable-options,$(RUSTFLAGS)),)
+RUSTFLAGS += -Z unstable-options
+endif
+endif
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 CLIPPY_LINTS := -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic

--- a/projects/web3/eth_wallet/host/src/main.rs
+++ b/projects/web3/eth_wallet/host/src/main.rs
@@ -78,6 +78,7 @@ pub fn derive_address(wallet_id: uuid::Uuid, hd_path: &str) -> Result<[u8; 20]> 
     Ok(output.address)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn sign_transaction(
     wallet_id: uuid::Uuid,
     hd_path: &str,
@@ -123,7 +124,7 @@ fn main() -> Result<()> {
         }
         cli::Command::DeriveAddress(opt) => {
             let address = derive_address(opt.wallet_id, &opt.hd_path)?;
-            println!("Address: 0x{}", hex::encode(&address));
+            println!("Address: 0x{}", hex::encode(address));
         }
         cli::Command::SignTransaction(opt) => {
             let signature = sign_transaction(
@@ -139,7 +140,7 @@ fn main() -> Result<()> {
             println!("Signature: {}", hex::encode(&signature));
         }
         cli::Command::Test => {
-            tests::tests::test_workflow();
+            tests::test_workflow()?;
             println!("Tests passed");
         }
     }

--- a/projects/web3/eth_wallet/host/src/tests.rs
+++ b/projects/web3/eth_wallet/host/src/tests.rs
@@ -15,23 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod tests {
-    use crate::*;
+use crate::*;
 
-    pub fn test_workflow() {
-        // Simulate the workflow of creating a wallet, deriving an address, and signing a transaction
-        let wallet_id = create_wallet().unwrap();
-        let address = derive_address(wallet_id, "m/44'/60'/0'/0/0").unwrap();
-        let result = sign_transaction(
-            wallet_id,
-            "m/44'/60'/0'/0/0",
-            5,
-            0,
-            address,
-            100,
-            1000000000,
-            21000,
-        );
-        assert!(result.is_ok());
-    }
+pub fn test_workflow() -> anyhow::Result<()> {
+    // Simulate the workflow of creating a wallet, deriving an address, and signing a transaction
+    let wallet_id = create_wallet()?;
+    let address = derive_address(wallet_id, "m/44'/60'/0'/0/0")?;
+    sign_transaction(
+        wallet_id,
+        "m/44'/60'/0'/0/0",
+        5,
+        0,
+        address,
+        100,
+        1000000000,
+        21000,
+    )?;
+    Ok(())
 }

--- a/projects/web3/eth_wallet/ta/Cargo.lock
+++ b/projects/web3/eth_wallet/ta/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -404,13 +404,13 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
-
-[[package]]
-name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
 
 [[package]]
 name = "libc_alloc"
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -647,7 +647,6 @@ dependencies = [
  "bincode",
  "hashbrown",
  "optee-utee",
- "optee-utee-sys",
  "serde",
 ]
 
@@ -785,7 +784,7 @@ dependencies = [
  "bip32",
  "ethereum-tx-sign",
  "hex",
- "libc 0.2.182",
+ "libc 0.2.189",
  "optee-utee",
  "optee-utee-build",
  "optee-utee-sys",

--- a/projects/web3/eth_wallet/ta/Cargo.toml
+++ b/projects/web3/eth_wallet/ta/Cargo.toml
@@ -24,6 +24,10 @@ repository = "https://github.com/apache/teaclave-trustzone-sdk.git"
 description = "An example of Ethereum wallet TA."
 edition = "2018"
 
+[features]
+default = []
+std = []
+
 [dependencies]
 libc = { path = "../../../../rust/libc" }
 proto = { path = "../proto" }

--- a/projects/web3/eth_wallet/ta/Makefile
+++ b/projects/web3/eth_wallet/ta/Makefile
@@ -27,7 +27,7 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 # fix for the error: "unwinding panics are not supported without std" reported by clippy
 # Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
+RUSTFLAGS := -C panic=abort -Z unstable-options
 # CARGO_FLAGS is set by sourcing environment (e.g. -Z build-std=std,panic_abort for std builds)
 CARGO_FLAGS ?= 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -18,7 +18,7 @@
 # Toolchain override for rustup
 
 [toolchain]
-channel = "nightly-2025-12-11"
+channel = "nightly-2026-08-05"
 components = [ "rust-src", "rustfmt", "clippy" ]
 targets = ["aarch64-unknown-linux-gnu", "arm-unknown-linux-gnueabihf"]
 # minimal profile: install rustc, cargo, and rust-std

--- a/scripts/runtime/config/ta/std/aarch64
+++ b/scripts/runtime/config/ta/std/aarch64
@@ -20,7 +20,8 @@ export TARGET_TA="aarch64-unknown-optee"
 export CROSS_COMPILE_TA="aarch64-linux-gnu-"
 
 # CARGO_FLAGS for building std TAs with cargo -Z build-std
-export CARGO_FLAGS="-Z build-std=std,panic_abort"
+export CARGO_FLAGS="-Z build-std=std,panic_abort -Z json-target-spec"
+export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-Z unstable-options"
 # rust library source for cargo -Z build-std
 export __CARGO_TESTS_ONLY_SRC_ROOT=$RUST_STD_DIR/rust/library
 # enable std feature for building std TAs (defined in TA's Cargo.toml and used in TA's Makefile)

--- a/scripts/setup-std/setup_rust_std.sh
+++ b/scripts/setup-std/setup_rust_std.sh
@@ -28,32 +28,34 @@ set -xe
 #  $RUST_STD_DIR/$customized-target1.json
 #  $RUST_STD_DIR/$customized-target2.json
 
-mkdir -p $RUST_STD_DIR
-cd $RUST_STD_DIR
+mkdir -p "$RUST_STD_DIR"
+cd "$RUST_STD_DIR"
 
 # Set up Rust and Cargo environment (RUSTUP_HOME and CARGO_HOME are set in bootstrap_env)
-source ${CARGO_HOME}/env
+source "${CARGO_HOME}/env"
 
 # initialize submodules: rust / libc with pinned versions for reproducible builds
-RUST_TAG=1.93.1        # commit 01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf
-LIBC_TAG=0.2.182       # commit e879ee90b6cd8f79b352d4d4d1f8ca05f94f2f53
+RUST_TAG=1ed2df61a19042f231709eb05d032ae9e2cb2084 # nightly-2026-08-05
+LIBC_TAG=0.2.189
 
 echo "Cloning rust (tag: $RUST_TAG) and libc (tag: $LIBC_TAG)..."
 
-# Clone official Rust source at specific tag
-git clone --depth=1 --branch $RUST_TAG https://github.com/rust-lang/rust.git && \
+# Clone official Rust source, then select the exact revision in RUST_TAG
+git clone --filter=blob:none --no-checkout https://github.com/rust-lang/rust.git rust && \
     (cd rust && \
+    git fetch --depth=1 origin "$RUST_TAG" && \
+    git checkout --detach FETCH_HEAD && \
     git submodule update --init library/stdarch && \
     git submodule update --init library/backtrace)
 
 # Clone official libc at specific tag
-git clone --depth=1 --branch $LIBC_TAG https://github.com/rust-lang/libc.git
+git clone --depth=1 --branch "$LIBC_TAG" https://github.com/rust-lang/libc.git
 
 # Clone patches repository
 git clone --depth=1 https://github.com/apache/teaclave-crates.git patches
 
 # Apply patches
-(cd rust && git apply ../patches/rust-1.93.1-01f6ddf/optee-0001-std-adaptation.patch)
-(cd libc && git apply ../patches/libc-0.2.182-e879ee9/optee-0001-libc-adaptation.patch)
+(cd rust && git apply ../patches/rust-1.99.0-1ed2df6/optee-0001-std-adaptation.patch)
+(cd libc && git apply ../patches/libc-0.2.189-ef0906e/optee-0001-libc-adaptation.patch)
 
 echo "rust-std initialized at $RUST_STD_DIR"

--- a/setup_std_dependencies.sh
+++ b/setup_std_dependencies.sh
@@ -21,12 +21,13 @@ set -xe
 
 ##########################################
 # move to project root
-cd "$(dirname "$0")"
+PROJECT_ROOT="$(cd -- "$(dirname -- "$0")" && pwd)"
+cd "$PROJECT_ROOT"
 
 ##########################################
-# initialize submodules: rust / libc / patches
-RUST_TAG=1.93.1        # commit 01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf
-LIBC_TAG=0.2.182       # commit e879ee90b6cd8f79b352d4d4d1f8ca05f94f2f53
+# initialize Rust and libc at pinned revisions, plus their OP-TEE patches
+RUST_TAG=1ed2df61a19042f231709eb05d032ae9e2cb2084 # nightly-2026-08-05
+LIBC_TAG=0.2.189
 
 if [ -d rust/ ]
 then
@@ -35,20 +36,22 @@ fi
 
 mkdir rust && cd rust
 
-# Clone official Rust source at specific tag
-git clone --depth=1 --branch $RUST_TAG https://github.com/rust-lang/rust.git && \
+# Clone official Rust source, then select the exact revision in RUST_TAG
+git clone --filter=blob:none --no-checkout https://github.com/rust-lang/rust.git rust && \
 	(cd rust && \
+	git fetch --depth=1 origin "$RUST_TAG" && \
+	git checkout --detach FETCH_HEAD && \
 	git submodule update --init library/stdarch && \
 	git submodule update --init library/backtrace)
 
 # Clone official libc at specific tag
-git clone --depth=1 --branch $LIBC_TAG https://github.com/rust-lang/libc.git
+git clone --depth=1 --branch "$LIBC_TAG" https://github.com/rust-lang/libc.git
 
 # Clone patches repository
 git clone --depth=1 https://github.com/apache/teaclave-crates.git patches
 
 # Apply patches
-(cd rust && git apply ../patches/rust-1.93.1-01f6ddf/optee-0001-std-adaptation.patch)
-(cd libc && git apply ../patches/libc-0.2.182-e879ee9/optee-0001-libc-adaptation.patch)
+(cd rust && git apply ../patches/rust-1.99.0-1ed2df6/optee-0001-std-adaptation.patch)
+(cd libc && git apply ../patches/libc-0.2.189-ef0906e/optee-0001-libc-adaptation.patch)
 
 echo "Rust and libc sources initialized and patched"

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -15,17 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-export TA_DEV_KIT_DIR="$OPTEE_OS_DIR/out/arm-plat-vexpress/export-ta_arm32"
-export TARGET_TA="arm-unknown-optee"
-export CROSS_COMPILE_TA="arm-linux-gnueabihf-"
-
-# CARGO_FLAGS for building std TAs with cargo -Z build-std
-export CARGO_FLAGS="-Z build-std=std,panic_abort -Z json-target-spec"
-export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-Z unstable-options"
-# rust library source for cargo -Z build-std
-export __CARGO_TESTS_ONLY_SRC_ROOT=$RUST_STD_DIR/rust/library
-# enable std feature for building std TAs (defined in TA's Cargo.toml and used in TA's Makefile)
-export FEATURES="--features std"
-
-# assume $customized-target.json is located here
-export RUST_TARGET_PATH=$RUST_STD_DIR
+screenlog.*
+shared
+x86_64-optee-4.10.0-qemuv8-ubuntu-24.04*
+aarch64-optee-4.10.0-qemuv8-ubuntu-24.04*

--- a/tools/cargo-optee/README.md
+++ b/tools/cargo-optee/README.md
@@ -548,7 +548,7 @@ TA_DEV_KIT_DIR=/opt/optee/export-ta_arm32 \
 RUSTFLAGS="-C panic=abort" \
 RUST_TARGET_PATH=/tmp/cargo-optee-XXXXX \
 __CARGO_TESTS_ONLY_SRC_ROOT=/path/to/rust/library \
-cargo -Z build-std=std,panic_abort clippy --target arm-unknown-optee --features std --release \
+cargo -Z build-std=std,panic_abort -Z json-target-spec clippy --target arm-unknown-optee --features std --release \
   --manifest-path ./ta/Cargo.toml
 
 # 2. Build
@@ -556,7 +556,7 @@ TA_DEV_KIT_DIR=/opt/optee/export-ta_arm32 \
 RUSTFLAGS="-C panic=abort" \
 RUST_TARGET_PATH=/tmp/cargo-optee-XXXXX \
 __CARGO_TESTS_ONLY_SRC_ROOT=/path/to/rust/library \
-cargo -Z build-std=std,panic_abort build --target arm-unknown-optee --features std --release \
+cargo -Z build-std=std,panic_abort -Z json-target-spec build --target arm-unknown-optee --features std --release \
   --manifest-path ./ta/Cargo.toml \
   --config target.arm-unknown-optee.linker="arm-linux-gnueabihf-gcc"
 

--- a/tools/cargo-optee/aarch64-unknown-optee.json
+++ b/tools/cargo-optee/aarch64-unknown-optee.json
@@ -16,6 +16,6 @@
     "target-endian": "little",
     "target-pointer-width": 64,
     "vendor": "unknown",
-    "panic-strategy": "abort"
+    "panic-strategy": "abort",
+    "singlethread": true
   }
-  

--- a/tools/cargo-optee/src/ta_builder.rs
+++ b/tools/cargo-optee/src/ta_builder.rs
@@ -326,11 +326,12 @@ fn setup_build_command(
         None
     };
 
-    // Always use cargo; std builds pass -Z build-std=std,panic_abort
+    // Always use cargo; std builds use the patched standard library and JSON targets.
     let mut cmd = cargo_command();
     cmd.arg(command);
     if config.std {
         cmd.arg("-Z").arg("build-std=std,panic_abort");
+        cmd.arg("-Z").arg("json-target-spec");
     }
     cmd.arg("--target").arg(&target);
 
@@ -365,6 +366,9 @@ fn setup_build_command(
         rustflags.push(' ');
     }
     rustflags.push_str("-C panic=abort");
+    if config.std && !rustflags.contains("unstable-options") {
+        rustflags.push_str(" -Z unstable-options");
+    }
     cmd.env("RUSTFLAGS", &rustflags);
 
     // Apply custom environment variables


### PR DESCRIPTION
- Pin rustc to nightly-2026-08-05 (1ed2df61) and libc to 0.2.189.
- Mark OP-TEE JSON targets as single-threaded and enable the new Cargo/rustc JSON target gates.
- Update cargo-optee so std builds pass json-target-spec and unstable-options without duplicating RUSTFLAGS.
- Fix nightly Clippy and macro expression compatibility in the SDK examples, including eth_wallet std builds.
- Fix ffi function that returns c_void.